### PR TITLE
Add unittest

### DIFF
--- a/nbsearch/server.py
+++ b/nbsearch/server.py
@@ -19,7 +19,7 @@ DEFAULT_TEMPLATE_PATH_LIST = [
 ]
 
 
-def get_api_handler_settings(parent_app, base_dir):
+def get_api_handlers(parent_app, base_dir):
     dbconfig = NBSearchDB(parent=parent_app)
     db = dbconfig.get_database()
 
@@ -27,10 +27,7 @@ def get_api_handler_settings(parent_app, base_dir):
     handler_settings['database'] = db
     handler_settings['collection'] = db[dbconfig.collection]
     handler_settings['base_dir'] = base_dir
-    return handler_settings
 
-
-def get_api_handlers(handler_settings):
     return [
         (r"/v1/search", SearchHandler, handler_settings),
         (r"/v1/download/(?P<id>[^\/]+)", DownloadHandler, handler_settings),
@@ -40,8 +37,7 @@ def get_api_handlers(handler_settings):
 
 def register_routes(nb_server_app, web_app):
     from notebook.utils import url_path_join
-    api_handler_settings = get_api_handler_settings(nb_server_app, nb_server_app.notebook_dir)
-    api_handlers = get_api_handlers(api_handler_settings)
+    api_handlers = get_api_handlers(nb_server_app, nb_server_app.notebook_dir)
 
     host_pattern = '.*$'
     handlers = [(url_path_join(web_app.settings['base_url'], 'nbsearch', path),
@@ -58,8 +54,7 @@ class ServerApp(tornado.web.Application):
         settings['static_path'] = DEFAULT_STATIC_FILES_PATH
         settings['template_path'] = DEFAULT_TEMPLATE_PATH_LIST[-1]
 
-        api_handler_settings = get_api_handler_settings(nbsearch_app, '.')
-        handlers = get_api_handlers(api_handler_settings) + [
+        handlers = get_api_handlers(nbsearch_app, '.') + [
             (r"/", MainHandler),
             (r"/static/(.*)", tornado.web.StaticFileHandler)
         ]

--- a/nbsearch/server.py
+++ b/nbsearch/server.py
@@ -34,7 +34,7 @@ def get_api_handlers(handler_settings):
     return [
         (r"/v1/search", SearchHandler, handler_settings),
         (r"/v1/download/(?P<id>[^\/]+)", DownloadHandler, handler_settings),
-        (r"/v1/import(?P<path>/.*)?/(?P<id>[^\/]+)", ImportHandler, handler_settings),
+        (r"/v1/import(?P<path>/.+)?/(?P<id>[^\/]+)", ImportHandler, handler_settings),
     ]
 
 

--- a/nbsearch/tests/test_api.py
+++ b/nbsearch/tests/test_api.py
@@ -16,37 +16,54 @@ collection_name = 'test_notebooks'
 class ApiHandlerTestCaseBase(tornado.testing.AsyncHTTPTestCase):
 
     def setUp(self):
-        self.db = mock.Mock()
-        self.collection = mock.Mock()
         self.base_dir = tempfile.mkdtemp()
-        self.handler_settings = {
-            'database': self.db,
-            'collection': self.collection,
-            'base_dir': self.base_dir,
-        }
+        self.collection = mock.Mock()
+        self.db = {collection_name: self.collection}
+        self.dbconfig = mock.Mock()
+        self.dbconfig.get_database = mock.Mock()
+        self.dbconfig.get_database.return_value = self.db
+        self.dbconfig.collection = collection_name
+        self.mock_nbsearchdb = mock.patch.object(
+            nbsearch.server,
+            'NBSearchDB',
+            return_value=self.dbconfig
+        )
+        self.mock_nbsearchdb.start()
         super().setUp()
 
     def tearDown(self):
         shutil.rmtree(self.base_dir)
+        self.mock_nbsearchdb.stop()
         super().tearDown()
 
     def get_app(self):
         return tornado.web.Application(
-            nbsearch.server.get_api_handlers(self.handler_settings)
+            nbsearch.server.get_api_handlers(None, self.base_dir)
         )
 
 
 class TestDownloadHandler(ApiHandlerTestCaseBase):
 
-    @mock.patch.object(motor.motor_tornado, 'MotorGridFSBucket')
-    def test_download(self, mock_fs_init):
+    def setUp(self):
+        super().setUp()
+        self.mock_fs = mock.Mock()
+        self.mock_fs.download_to_stream = AsyncMock()
+        self.mock_fs_init = mock.patch.object(
+            motor.motor_tornado,
+            'MotorGridFSBucket',
+            return_value=self.mock_fs
+        )
+        self.mock_fs_init.start()
+
+    def tearDown(self):
+        self.mock_fs_init.stop()
+        super().tearDown()
+
+    def test_download(self):
         notebook_file_id = '0123456789ab0123456789ab'
         notebook_filename = 'notebook1.ipynb'
         notebook = {'path': os.path.join(self.base_dir, notebook_filename)}
 
-        mock_fs = mock.Mock()
-        mock_fs.download_to_stream = AsyncMock()
-        mock_fs_init.return_value = mock_fs
         self.collection.find_one = AsyncMock()
         self.collection.find_one.return_value = notebook
 
@@ -59,8 +76,8 @@ class TestDownloadHandler(ApiHandlerTestCaseBase):
         self.assertEqual(response.headers['Content-Type'],
                          'application/json; charset=utf-8')
 
-        self.assertEqual(mock_fs.download_to_stream.call_count, 1)
-        self.assertEqual(str(mock_fs.download_to_stream.call_args[0][0]), notebook_file_id)
+        self.assertEqual(self.mock_fs.download_to_stream.call_count, 1)
+        self.assertEqual(str(self.mock_fs.download_to_stream.call_args[0][0]), notebook_file_id)
 
 
 class TestImportHandler(ApiHandlerTestCaseBase):
@@ -72,31 +89,34 @@ class TestImportHandler(ApiHandlerTestCaseBase):
         self.notebook = {'path': os.path.join(self.base_dir, self.notebook_filename)}
         self.collection.find_one = AsyncMock()
         self.collection.find_one.return_value = self.notebook
+        self.mock_fs = mock.Mock()
+        self.mock_fs.download_to_stream = AsyncMock()
+        self.mock_fs_init = mock.patch.object(
+            motor.motor_tornado,
+            'MotorGridFSBucket',
+            return_value=self.mock_fs
+        )
+        self.mock_fs_init.start()
 
     def tearDown(self):
+        self.mock_fs_init.stop()
         super().tearDown()
 
-    @mock.patch.object(motor.motor_tornado, 'MotorGridFSBucket')
-    def test_import(self, mock_fs_init):
+    def test_import(self):
         dest_path = 'dest'
         dest_full_path = os.path.join(self.base_dir, dest_path)
         os.mkdir(dest_full_path)
 
-        mock_fs = mock.Mock()
-        mock_fs.download_to_stream = AsyncMock()
-        mock_fs_init.return_value = mock_fs
-
         response = self.fetch('/v1/import/{}/{}'.format(dest_path, self.notebook_file_id))
         self.assertEqual(response.code, 200)
 
-        self.assertEqual(mock_fs.download_to_stream.call_count, 1)
-        self.assertEqual(str(mock_fs.download_to_stream.call_args[0][0]), self.notebook_file_id)
-        self.assertIsInstance(mock_fs.download_to_stream.call_args[0][1], io.BufferedIOBase)
-        self.assertEqual(mock_fs.download_to_stream.call_args[0][1].name,
+        self.assertEqual(self.mock_fs.download_to_stream.call_count, 1)
+        self.assertEqual(str(self.mock_fs.download_to_stream.call_args[0][0]), self.notebook_file_id)
+        self.assertIsInstance(self.mock_fs.download_to_stream.call_args[0][1], io.BufferedIOBase)
+        self.assertEqual(self.mock_fs.download_to_stream.call_args[0][1].name,
                          os.path.join(dest_full_path, self.notebook_filename))
 
-    @mock.patch.object(motor.motor_tornado, 'MotorGridFSBucket')
-    def test_import_multiple(self, mock_fs_init):
+    def test_import_multiple(self):
         dest_notebook_filenames = [
             'notebook1.ipynb',
             'notebook1 (1).ipynb',
@@ -106,37 +126,28 @@ class TestImportHandler(ApiHandlerTestCaseBase):
         dest_full_path = os.path.join(self.base_dir, dest_path)
         os.mkdir(dest_full_path)
 
-        mock_fs = mock.Mock()
-        mock_fs_init.return_value = mock_fs
-
         for dest_notebook_filename in dest_notebook_filenames:
-            mock_fs.download_to_stream = AsyncMock()
+            self.mock_fs.download_to_stream = AsyncMock()
             response = self.fetch('/v1/import/{}/{}'.format(dest_path, self.notebook_file_id))
             self.assertEqual(response.code, 200)
-            self.assertEqual(mock_fs.download_to_stream.call_count, 1)
-            self.assertEqual(mock_fs.download_to_stream.call_args[0][1].name,
+            self.assertEqual(self.mock_fs.download_to_stream.call_count, 1)
+            self.assertEqual(self.mock_fs.download_to_stream.call_args[0][1].name,
                              os.path.join(dest_full_path, dest_notebook_filename))
 
-    @mock.patch.object(motor.motor_tornado, 'MotorGridFSBucket')
-    def test_import_to_nested_path(self, mock_fs_init):
+    def test_import_to_nested_path(self):
         dest_path = 'dest/a/b/c'
         dest_full_path = os.path.join(self.base_dir, dest_path)
         os.makedirs(dest_full_path, exist_ok=True)
 
-        mock_fs = mock.Mock()
-        mock_fs.download_to_stream = AsyncMock()
-        mock_fs_init.return_value = mock_fs
-
         response = self.fetch('/v1/import/{}/{}'.format(dest_path, self.notebook_file_id))
         self.assertEqual(response.code, 200)
 
-        self.assertEqual(mock_fs.download_to_stream.call_count, 1)
-        self.assertEqual(str(mock_fs.download_to_stream.call_args[0][0]), self.notebook_file_id)
-        self.assertEqual(mock_fs.download_to_stream.call_args[0][1].name,
+        self.assertEqual(self.mock_fs.download_to_stream.call_count, 1)
+        self.assertEqual(str(self.mock_fs.download_to_stream.call_args[0][0]), self.notebook_file_id)
+        self.assertEqual(self.mock_fs.download_to_stream.call_args[0][1].name,
                          os.path.join(dest_full_path, self.notebook_filename))
 
-    @mock.patch.object(motor.motor_tornado, 'MotorGridFSBucket')
-    def test_import_multiple_to_nested_path(self, mock_fs_init):
+    def test_import_multiple_to_nested_path(self):
         dest_notebook_filenames = [
             'notebook1.ipynb',
             'notebook1 (1).ipynb',
@@ -146,54 +157,40 @@ class TestImportHandler(ApiHandlerTestCaseBase):
         dest_full_path = os.path.join(self.base_dir, dest_path)
         os.makedirs(dest_full_path, exist_ok=True)
 
-        mock_fs = mock.Mock()
-        mock_fs_init.return_value = mock_fs
-
         for dest_notebook_filename in dest_notebook_filenames:
-            mock_fs.download_to_stream = AsyncMock()
+            self.mock_fs.download_to_stream = AsyncMock()
             response = self.fetch('/v1/import/{}/{}'.format(dest_path, self.notebook_file_id))
             self.assertEqual(response.code, 200)
-            self.assertEqual(mock_fs.download_to_stream.call_count, 1)
-            self.assertEqual(mock_fs.download_to_stream.call_args[0][1].name,
+            self.assertEqual(self.mock_fs.download_to_stream.call_count, 1)
+            self.assertEqual(self.mock_fs.download_to_stream.call_args[0][1].name,
                              os.path.join(dest_full_path, dest_notebook_filename))
 
-    @mock.patch.object(motor.motor_tornado, 'MotorGridFSBucket')
-    def test_import_to_empty_path(self, mock_fs_init):
-        mock_fs = mock.Mock()
-        mock_fs.download_to_stream = AsyncMock()
-        mock_fs_init.return_value = mock_fs
-
+    def test_import_to_empty_path(self):
         response = self.fetch('/v1/import/{}/{}'.format('', self.notebook_file_id))
         self.assertEqual(response.code, 404)
 
-    @mock.patch.object(motor.motor_tornado, 'MotorGridFSBucket')
-    def test_import_to_including_dot_path(self, mock_fs_init):
-        mock_fs = mock.Mock()
-        mock_fs_init.return_value = mock_fs
+    def test_import_to_including_dot_path(self):
         dest_paths = [
             '..', '../x', 'x/..', 'x/../y',
             '.', './x', 'x/.', 'x/./y',
         ]
 
         for dest_path in dest_paths:
-            mock_fs.download_to_stream = AsyncMock()
+            self.mock_fs.download_to_stream = AsyncMock()
             response = self.fetch('/v1/import/{}/{}'.format(dest_path, self.notebook_file_id))
             self.assertEqual(response.code, 400)
-            self.assertEqual(mock_fs.download_to_stream.call_count, 0)
+            self.assertEqual(self.mock_fs.download_to_stream.call_count, 0)
 
-    @mock.patch.object(motor.motor_tornado, 'MotorGridFSBucket')
-    def test_import_to_start_with_multiple_slashed_path(self, mock_fs_init):
-        mock_fs = mock.Mock()
-        mock_fs_init.return_value = mock_fs
+    def test_import_to_start_with_multiple_slashed_path(self):
         dest_paths = [
             '//x', '///x',
         ]
 
         for dest_path in dest_paths:
-            mock_fs.download_to_stream = AsyncMock()
+            self.mock_fs.download_to_stream = AsyncMock()
             response = self.fetch('/v1/import/{}/{}'.format(dest_path, self.notebook_file_id))
             self.assertEqual(response.code, 400)
-            self.assertEqual(mock_fs.download_to_stream.call_count, 0)
+            self.assertEqual(self.mock_fs.download_to_stream.call_count, 0)
 
 
 if __name__ == '__main__':

--- a/nbsearch/tests/test_api.py
+++ b/nbsearch/tests/test_api.py
@@ -1,0 +1,208 @@
+import io
+import shutil
+import tempfile
+import unittest
+import tornado.testing
+import tornado.web
+import mock
+import nbsearch.server
+import os
+from nbsearch.v1.handlers import DownloadHandler, ImportHandler
+from .utils import AsyncMock
+
+collection_name = 'test_notebooks'
+
+
+class ApiHandlerTestCaseBase(tornado.testing.AsyncHTTPTestCase):
+
+    def setUp(self):
+        self.db = mock.Mock()
+        self.collection = mock.Mock()
+        self.base_dir = tempfile.mkdtemp()
+        self.handler_settings = {
+            'database': self.db,
+            'collection': self.collection,
+            'base_dir': self.base_dir,
+        }
+        super().setUp()
+
+    def tearDown(self):
+        shutil.rmtree(self.base_dir)
+        super().tearDown()
+
+    def get_app(self):
+        return tornado.web.Application(
+            nbsearch.server.get_api_handlers(self.handler_settings)
+        )
+
+
+class TestDownloadHandler(ApiHandlerTestCaseBase):
+
+    @mock.patch.object(DownloadHandler, '_get_fs')
+    def test_download(self, mock_get_fs):
+        notebook_file_id = '0123456789ab0123456789ab'
+        notebook_filename = 'notebook1.ipynb'
+        notebook = {'path': os.path.join(self.base_dir, notebook_filename)}
+
+        mock_fs = mock.Mock()
+        mock_fs.download_to_stream = AsyncMock()
+        mock_get_fs.return_value = mock_fs
+        self.collection.find_one = AsyncMock()
+        self.collection.find_one.return_value = notebook
+
+        response = self.fetch('/v1/download/{}'.format(notebook_file_id))
+        self.assertEqual(response.code, 200)
+        self.assertIn('Content-Disposition', response.headers)
+        self.assertEqual(response.headers['Content-Disposition'],
+                         'attachment; filename="{}"'.format(notebook_filename))
+        self.assertIn('Content-Type', response.headers)
+        self.assertEqual(response.headers['Content-Type'],
+                         'application/json; charset=utf-8')
+
+        self.assertEqual(mock_fs.download_to_stream.call_count, 1)
+        self.assertEqual(str(mock_fs.download_to_stream.call_args[0][0]), notebook_file_id)
+
+
+class TestImportHandler(ApiHandlerTestCaseBase):
+
+    def setUp(self):
+        super().setUp()
+        self.notebook_file_id = '0123456789ab0123456789ab'
+        self.notebook_filename = 'notebook1.ipynb'
+        self.notebook = {'path': os.path.join(self.base_dir, self.notebook_filename)}
+        self.collection.find_one = AsyncMock()
+        self.collection.find_one.return_value = self.notebook
+
+    def tearDown(self):
+        super().tearDown()
+
+    @mock.patch.object(ImportHandler, '_get_fs')
+    def test_import(self, mock_get_fs):
+        dest_path = 'dest'
+        dest_full_path = os.path.join(self.base_dir, dest_path)
+        os.mkdir(dest_full_path)
+
+        mock_fs = mock.Mock()
+        mock_fs.download_to_stream = AsyncMock()
+        mock_get_fs.return_value = mock_fs
+
+        response = self.fetch('/v1/import/{}/{}'.format(dest_path, self.notebook_file_id))
+        self.assertEqual(response.code, 200)
+
+        self.assertEqual(mock_fs.download_to_stream.call_count, 1)
+        self.assertEqual(str(mock_fs.download_to_stream.call_args[0][0]), self.notebook_file_id)
+        self.assertIsInstance(mock_fs.download_to_stream.call_args[0][1], io.BufferedIOBase)
+        self.assertEqual(mock_fs.download_to_stream.call_args[0][1].name,
+                         os.path.join(dest_full_path, self.notebook_filename))
+
+    @mock.patch.object(ImportHandler, '_get_fs')
+    def test_import_multiple(self, mock_get_fs):
+        dest_notebook_filenames = [
+            'notebook1.ipynb',
+            'notebook1 (1).ipynb',
+            'notebook1 (2).ipynb',
+        ]
+        dest_path = 'dest'
+        dest_full_path = os.path.join(self.base_dir, dest_path)
+        os.mkdir(dest_full_path)
+
+        mock_fs = mock.Mock()
+        mock_get_fs.return_value = mock_fs
+
+        for dest_notebook_filename in dest_notebook_filenames:
+            mock_fs.download_to_stream = AsyncMock()
+            response = self.fetch('/v1/import/{}/{}'.format(dest_path, self.notebook_file_id))
+            self.assertEqual(response.code, 200)
+            self.assertEqual(mock_fs.download_to_stream.call_count, 1)
+            self.assertEqual(mock_fs.download_to_stream.call_args[0][1].name,
+                             os.path.join(dest_full_path, dest_notebook_filename))
+
+    @mock.patch.object(ImportHandler, '_get_fs')
+    def test_import_to_nested_path(self, mock_get_fs):
+        dest_path = 'dest/a/b/c'
+        dest_full_path = os.path.join(self.base_dir, dest_path)
+        os.makedirs(dest_full_path, exist_ok=True)
+
+        mock_fs = mock.Mock()
+        mock_fs.download_to_stream = AsyncMock()
+        mock_get_fs.return_value = mock_fs
+
+        response = self.fetch('/v1/import/{}/{}'.format(dest_path, self.notebook_file_id))
+        self.assertEqual(response.code, 200)
+
+        self.assertEqual(mock_fs.download_to_stream.call_count, 1)
+        self.assertEqual(str(mock_fs.download_to_stream.call_args[0][0]), self.notebook_file_id)
+        self.assertEqual(mock_fs.download_to_stream.call_args[0][1].name,
+                         os.path.join(dest_full_path, self.notebook_filename))
+
+    @mock.patch.object(ImportHandler, '_get_fs')
+    def test_import_multiple_to_nested_path(self, mock_get_fs):
+        dest_notebook_filenames = [
+            'notebook1.ipynb',
+            'notebook1 (1).ipynb',
+            'notebook1 (2).ipynb',
+        ]
+        dest_path = 'dest'
+        dest_full_path = os.path.join(self.base_dir, dest_path)
+        os.makedirs(dest_full_path, exist_ok=True)
+
+        mock_fs = mock.Mock()
+        mock_get_fs.return_value = mock_fs
+
+        for dest_notebook_filename in dest_notebook_filenames:
+            mock_fs.download_to_stream = AsyncMock()
+            response = self.fetch('/v1/import/{}/{}'.format(dest_path, self.notebook_file_id))
+            self.assertEqual(response.code, 200)
+            self.assertEqual(mock_fs.download_to_stream.call_count, 1)
+            self.assertEqual(mock_fs.download_to_stream.call_args[0][1].name,
+                             os.path.join(dest_full_path, dest_notebook_filename))
+
+    @mock.patch.object(ImportHandler, '_get_fs')
+    def test_import_to_empty_path(self, mock_get_fs):
+        dest_path = ''
+        dest_full_path = os.path.join(self.base_dir, dest_path)
+
+        mock_fs = mock.Mock()
+        mock_fs.download_to_stream = AsyncMock()
+        mock_get_fs.return_value = mock_fs
+
+        response = self.fetch('/v1/import/{}/{}'.format(dest_path, self.notebook_file_id))
+        self.assertEqual(response.code, 200)
+
+        self.assertEqual(mock_fs.download_to_stream.call_count, 1)
+        self.assertEqual(str(mock_fs.download_to_stream.call_args[0][0]), self.notebook_file_id)
+        self.assertEqual(mock_fs.download_to_stream.call_args[0][1].name,
+                         os.path.join(dest_full_path, self.notebook_filename))
+
+    @mock.patch.object(ImportHandler, '_get_fs')
+    def test_import_to_including_dot_path(self, mock_get_fs):
+        mock_fs = mock.Mock()
+        mock_get_fs.return_value = mock_fs
+        dest_paths = [
+            '..', '../x', 'x/..', 'x/../y',
+            '.', './x', 'x/.', 'x/./y',
+        ]
+
+        for dest_path in dest_paths:
+            mock_fs.download_to_stream = AsyncMock()
+            response = self.fetch('/v1/import/{}/{}'.format(dest_path, self.notebook_file_id))
+            self.assertEqual(response.code, 400)
+            self.assertEqual(mock_fs.download_to_stream.call_count, 0)
+
+    @mock.patch.object(ImportHandler, '_get_fs')
+    def test_import_to_start_with_multiple_slashed_path(self, mock_get_fs):
+        mock_fs = mock.Mock()
+        mock_get_fs.return_value = mock_fs
+        dest_paths = [
+            '//x', '///x',
+        ]
+
+        for dest_path in dest_paths:
+            mock_fs.download_to_stream = AsyncMock()
+            response = self.fetch('/v1/import/{}/{}'.format(dest_path, self.notebook_file_id))
+            self.assertEqual(response.code, 400)
+            self.assertEqual(mock_fs.download_to_stream.call_count, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/nbsearch/tests/utils.py
+++ b/nbsearch/tests/utils.py
@@ -1,0 +1,6 @@
+import mock
+
+
+class AsyncMock(mock.MagicMock):
+    async def __call__(self, *args, **kwargs):
+        return super().__call__(*args, **kwargs)

--- a/nbsearch/v1/handlers.py
+++ b/nbsearch/v1/handlers.py
@@ -72,7 +72,7 @@ class DownloadHandler(tornado.web.RequestHandler):
         self.collection = collection
 
     async def get(self, id):
-        fs = self._get_fs()
+        fs = motor_tornado.MotorGridFSBucket(self.database)
         file_id = ObjectId(id)
         notebook = await self.collection.find_one({'_id': file_id})
         filename = os.path.basename(notebook['path'])
@@ -81,9 +81,6 @@ class DownloadHandler(tornado.web.RequestHandler):
         self.set_header('Content-Type', 'application/json; charset=utf-8')
         await fs.download_to_stream(file_id, self)
         self.finish()
-
-    def _get_fs(self):
-        return motor_tornado.MotorGridFSBucket(self.database)
 
 
 class ImportHandler(tornado.web.RequestHandler):
@@ -114,7 +111,7 @@ class ImportHandler(tornado.web.RequestHandler):
         return alt_filename
 
     async def get(self, path, id):
-        fs = self._get_fs()
+        fs = motor_tornado.MotorGridFSBucket(self.database)
         file_id = ObjectId(id)
         notebook = await self.collection.find_one({'_id': file_id})
         filename = os.path.basename(notebook['path'])
@@ -129,6 +126,3 @@ class ImportHandler(tornado.web.RequestHandler):
         with open(os.path.join(self.base_dir, path, filename), 'wb') as f:
             await fs.download_to_stream(file_id, f)
         self.write({'filename': filename})
-
-    def _get_fs(self):
-        return motor_tornado.MotorGridFSBucket(self.database)

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,11 @@ setup_args = dict(name='nbsearch',
           'notebook>=4.2.0',
           'motor',
       ],
+      extras_require={
+          'test': [
+              'mock',
+          ],
+      },
      )
 
 if __name__ == '__main__':


### PR DESCRIPTION
- [ ] Add unittest for:
    - [ ] SearchHandler
    - [x] DownloadHandler
    - [x] TestImportHandler
    - [ ] mongo query builder
- [ ] Add Travis settings

motorはmongomockでmockするのが難しかったので、リクエストごとMock化しています。
MotorGridFSBucketをmockするのが難しかったので、Handlerに`_get_fs()`メソッドを生やしてそれをMockしています（コンストラクタとメソッドを同時にモックするのが難しい）。

